### PR TITLE
Add sysconfig submodule to distutils import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages, Extension
 
 
 from distutils.core import setup
-import distutils
+import distutils.sysconfig
 import os
 import subprocess
 import sys


### PR DESCRIPTION
Add submodule to import to enable the `get_python_inc()` method.

This change fixes the following installation error:
```
Collecting gpudb
  Using cached gpudb-6.2.0.3.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-2vucd4wd/gpudb/setup.py", line 54, in <module>
        python_dev_path = distutils.sysconfig.get_python_inc()
    AttributeError: module 'distutils' has no attribute 'sysconfig'
```

Closes #6 